### PR TITLE
Stop using the deprecated request.REQUEST

### DIFF
--- a/endless_pagination/decorators.py
+++ b/endless_pagination/decorators.py
@@ -28,7 +28,7 @@ def page_template(template, key=PAGE_LABEL):
             extra_context = kwargs.setdefault('extra_context', {})
             extra_context['page_template'] = template
             # Switch the template when the request is Ajax.
-            querystring_key = request.REQUEST.get(
+            querystring_key = request.GET.get(
                 'querystring_key', PAGE_LABEL)
             if request.is_ajax() and querystring_key == key:
                 kwargs[TEMPLATE_VARNAME] = template
@@ -77,7 +77,7 @@ def page_templates(mapping):
             # Trust the developer: he wrote ``context.update(extra_context)``
             # in his view.
             extra_context = kwargs.setdefault('extra_context', {})
-            querystring_key = request.REQUEST.get(
+            querystring_key = request.GET.get(
                 'querystring_key', PAGE_LABEL)
             template = _get_template(querystring_key, mapping)
             extra_context['page_template'] = template

--- a/endless_pagination/loaders.py
+++ b/endless_pagination/loaders.py
@@ -1,9 +1,9 @@
 """Django Endless Pagination object loaders."""
+from importlib import import_module
 
 from __future__ import unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 
 
 def load_object(path):

--- a/endless_pagination/loaders.py
+++ b/endless_pagination/loaders.py
@@ -1,7 +1,7 @@
 """Django Endless Pagination object loaders."""
-from importlib import import_module
-
 from __future__ import unicode_literals
+
+from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
 

--- a/endless_pagination/utils.py
+++ b/endless_pagination/utils.py
@@ -43,7 +43,7 @@ def get_page_number_from_request(
     then *default* number is returned.
     """
     try:
-        return int(request.REQUEST[querystring_key])
+        return int(request.GET[querystring_key])
     except (KeyError, TypeError, ValueError):
         return default
 

--- a/endless_pagination/views.py
+++ b/endless_pagination/views.py
@@ -131,7 +131,7 @@ class AjaxMultipleObjectTemplateResponseMixin(
     def get_template_names(self):
         """Switch the templates for Ajax requests."""
         request = self.request
-        querystring_key = request.REQUEST.get('querystring_key', PAGE_LABEL)
+        querystring_key = request.GET.get('querystring_key', PAGE_LABEL)
         if request.is_ajax() and querystring_key == self.key:
             return [self.page_template]
         return super(


### PR DESCRIPTION
This also means we'll only look at the page parameter in request.GET.
